### PR TITLE
Separate Github API functions into separate file

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^1.10.0",
     "enzyme": "^3.1.1",
     "enzyme-adapter-react-16": "^1.0.4",
     "react-test-renderer": "^16.1.0"

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { get } from 'axios';
 
 import AppBar from 'material-ui/AppBar';
 

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import AppBar from 'material-ui/AppBar';
 import Results from './Results/Results';
 import SearchBar from './SearchBar/SearchBar';
 
+import { searchRepositories } from './utils/github';
+
 import './App.css';
 
 class App extends Component {
@@ -28,29 +30,13 @@ class App extends Component {
     this.searchDebounce = setTimeout(() => this.search(term), 500);
   }
 
-  async search(term) {
-    if(!term) {
-      this.setState({
-        results: [],
-        searchTerm: term
-      });
+  async search(searchTerm) {
+    const results = await searchRepositories(searchTerm);
 
-      return;
-    }
-
-    try {
-      const response = await get(`https://api.github.com/search/repositories?q=${term}&page=${this.state.currentPage}`);
-      this.setState({
-        results: response.data.items,
-        searchTerm: term
-      });
-    }
-    catch(e) {
-      this.setState({
-        results: [],
-        searchTerm: term
-      });
-    }
+    this.setState({
+      results,
+      searchTerm
+    });
   }
 
   render() {

--- a/src/utils/__tests__/github.test.js
+++ b/src/utils/__tests__/github.test.js
@@ -11,5 +11,31 @@ describe('Github API functions', () => {
     beforeEach(() => {
       axiosMock = new mockAdapter(axios);
     });
+
+    it('should return an empty array if the term isn\'t set', async () => {
+      const results = await searchRepositories('');
+      expect(results).toEqual([]);
+    });
+
+    it('should return an empty array of no results are returned from the API', async () =>{
+      axiosMock.onGet().reply(200, {
+        items: []
+      });
+
+      const results = await searchRepositories('test');
+      expect(results.length).toEqual(0);
+    });
+
+    it('should return an array of elements when searching', async () => {
+      axiosMock.onGet().reply(200, {
+        items: [
+          repositoryMock,
+          repositoryMock
+        ]
+      });
+
+      const results = await searchRepositories('test');
+      expect(results.length).toEqual(2);
+    });
   });
 });

--- a/src/utils/__tests__/github.test.js
+++ b/src/utils/__tests__/github.test.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import mockAdapter from 'axios-mock-adapter';
+
+import { GITHUB_API_URL, searchRepositories } from '../github';
+import repositoryMock from '../../__mocks__/repositoryMock';
+
+let axiosMock;
+
+describe('Github API functions', () => {
+  describe('searchRepositories', () => {
+    beforeEach(() => {
+      axiosMock = new mockAdapter(axios);
+    });
+  });
+});

--- a/src/utils/__tests__/github.test.js
+++ b/src/utils/__tests__/github.test.js
@@ -13,7 +13,12 @@ describe('Github API functions', () => {
     });
 
     it('should return an empty array if the term isn\'t set', async () => {
-      const results = await searchRepositories('');
+      const results = await searchRepositories();
+      expect(results).toEqual([]);
+    });
+
+    it('should return an empty array if the term is the empty string', async () => {
+      const results = await searchRepositories();
       expect(results).toEqual([]);
     });
 

--- a/src/utils/__tests__/github.test.js
+++ b/src/utils/__tests__/github.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import mockAdapter from 'axios-mock-adapter';
 
-import { GITHUB_API_URL, searchRepositories } from '../github';
+import { searchRepositories } from '../github';
 import repositoryMock from '../../__mocks__/repositoryMock';
 
 let axiosMock;

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -3,7 +3,7 @@
  */
 import { get } from 'axios';
 
-export const GITHUB_API_URL = 'https://api.github.com';
+const GITHUB_API_URL = 'https://api.github.com';
 
 export const searchRepositories = async (term, { sort = '', order = 'desc', page = 1 } = {}) => {
   if(!term) {

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,9 +1,19 @@
 /**
  * Github API functions
  */
+import { get } from 'axios';
 
 export const searchRepositories = async (term, { sort = '', order = 'desc', page = 1 } = {}) => {
   if(!term) {
+    return [];
+  }
+
+  try {
+    const response = await get(`${GITHUB_API_URL}/search/repositories?q=${term}&page=${page}&sort=${sort}&order=${order}`);
+
+    return response.data.items;
+  }
+  catch(e) {
     return [];
   }
 };

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,0 +1,3 @@
+/**
+ * Github API functions
+ */

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -2,7 +2,7 @@
  * Github API functions
  */
 
-export const searchRepositories = async (term, { sort: '', order: 'desc' }) => {
+export const searchRepositories = async (term, { sort = '', order = 'desc', page = 1 } = {}) => {
   if(!term) {
     return [];
   }

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,3 +1,7 @@
 /**
  * Github API functions
  */
+
+export const searchRepositories = async (term, { sort: '', order: 'desc' }) => {
+
+};

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -3,6 +3,8 @@
  */
 import { get } from 'axios';
 
+export const GITHUB_API_URL = 'https://api.github.com';
+
 export const searchRepositories = async (term, { sort = '', order = 'desc', page = 1 } = {}) => {
   if(!term) {
     return [];

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -3,5 +3,7 @@
  */
 
 export const searchRepositories = async (term, { sort: '', order: 'desc' }) => {
-
+  if(!term) {
+    return [];
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,12 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios-mock-adapter@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.10.0.tgz#3ccee65466439a2c7567e932798fc0377d39209d"
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.0.tgz#7da747916db803f761651d6091d708789b953c6a"


### PR DESCRIPTION
I created a separate file to hold all of the external Github API functions so that they can be used in any component. I named the function ```searchRepositories```, assuming eventually there will be a function for searching each of the different supported types from the Github API.

These changes include a few tests for the ```searchRepositories``` function.

I also added the axios-mock-adapter library, which makes it very easy to mock all API request made by axios. This is used to mock the Github Search API GET request.