### PR TITLE
Search Filters Panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,15 +27,15 @@ class App extends Component {
     this.handleSearchInput = this.handleSearchInput.bind(this);
   }
 
+  handleSearchInput(term) {
+    clearTimeout(this.searchDebounce);
+    this.searchDebounce = setTimeout(() => this.search(term), 500);
+  }
+
   handleSearchOptionsToggle = () => {
     this.setState({
       displaySearchOptions: !this.state.displaySearchOptions
     });
-  }
-
-  handleSearchInput(term) {
-    clearTimeout(this.searchDebounce);
-    this.searchDebounce = setTimeout(() => this.search(term), 500);
   }
 
   handleSortFilterChange = (event, index, value) => {

--- a/src/App.js
+++ b/src/App.js
@@ -62,6 +62,7 @@ class App extends Component {
 
   render() {
     const { displaySearchOptions, searchTerm, sortFilter, results } = this.state;
+
     return (
       <div>
         <AppBar

--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,7 @@ class App extends Component {
   handleSortFilterChange(event, index, value) {
     this.setState({
       sortFilter: value
-    });
+    }, () => this.search(this.state.searchTerm));
   }
 
   async search(searchTerm) {

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ class App extends Component {
       currentPage: 1,
       displayOptions: false,
       results: [],
+      sortFilter: '',
       searchTerm: ''
     };
 
@@ -63,8 +64,7 @@ class App extends Component {
   }
 
   render() {
-    const { displayOptions, searchTerm, results } = this.state;
-
+    const { displayOptions, searchTerm, sortFilter, results } = this.state;
     return (
       <div>
         <AppBar
@@ -76,6 +76,7 @@ class App extends Component {
           <SearchOptions
             handleToggle={this.handleOptionsToggle}
             open={displayOptions}
+            sortFilter={sortFilter}
           />
           {
             searchTerm.length > 0

--- a/src/App.js
+++ b/src/App.js
@@ -47,7 +47,14 @@ class App extends Component {
   }
 
   async search(searchTerm) {
-    const results = await searchRepositories(searchTerm);
+    const { displayOptions, sortFilter } = this.state;
+    const options = {};
+
+    if(displayOptions) {
+      options.sort = sortFilter;
+    }
+
+    const results = await searchRepositories(searchTerm, options);
 
     this.setState({
       results,

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ class App extends Component {
 
     this.state = {
       currentPage: 1,
-      displayOptions: false,
+      displaySearchOptions: false,
       results: [],
       sortFilter: '',
       searchTerm: ''
@@ -31,7 +31,7 @@ class App extends Component {
 
   handleOptionsToggle() {
     this.setState({
-      displayOptions: !this.state.displayOptions
+      displaySearchOptions: !this.state.displaySearchOptions
     });
   }
 
@@ -47,10 +47,10 @@ class App extends Component {
   }
 
   async search(searchTerm) {
-    const { displayOptions, sortFilter } = this.state;
+    const { displaySearchOptions, sortFilter } = this.state;
     const options = {};
 
-    if(displayOptions) {
+    if(displaySearchOptions) {
       options.sort = sortFilter;
     }
 
@@ -63,7 +63,7 @@ class App extends Component {
   }
 
   render() {
-    const { displayOptions, searchTerm, sortFilter, results } = this.state;
+    const { displaySearchOptions, searchTerm, sortFilter, results } = this.state;
     return (
       <div>
         <AppBar
@@ -78,7 +78,7 @@ class App extends Component {
           <SearchOptions
             handleSortFilterChange={this.handleSortFilterChange}
             handleToggle={this.handleOptionsToggle}
-            open={displayOptions}
+            open={displaySearchOptions}
             sortFilter={sortFilter}
           />
           {

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import AppBar from 'material-ui/AppBar';
 
 import Results from './Results/Results';
 import SearchBar from './SearchBar/SearchBar';
+import SearchOptions from './SearchOptions/SearchOptions';
 
 import './App.css';
 
@@ -64,6 +65,7 @@ class App extends Component {
         />
         <div className="search-container">
           <SearchBar handleSearchInput={this.handleSearchInput} />
+          <SearchOptions />
           {
             searchTerm.length > 0
             ? <Results results={results} searchTerm={searchTerm} />

--- a/src/App.js
+++ b/src/App.js
@@ -71,7 +71,10 @@ class App extends Component {
           title="Github Search React"
         />
         <div className="search-container">
-          <SearchBar handleSearchInput={this.handleSearchInput} />
+          <SearchBar
+            handleSearchInput={this.handleSearchInput}
+            sortFilter={sortFilter}
+          />
           <SearchOptions
             handleSortFilterChange={this.handleSortFilterChange}
             handleToggle={this.handleOptionsToggle}

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,14 @@ class App extends Component {
 
     this.searchDebounce = null;
 
+    this.handleOptionsToggle = this.handleOptionsToggle.bind(this);
     this.handleSearchInput = this.handleSearchInput.bind(this);
+  }
+
+  handleOptionsToggle() {
+    this.setState({
+      displayOptions: !this.state.displayOptions
+    });
   }
 
   handleSearchInput(term) {
@@ -67,6 +74,7 @@ class App extends Component {
         <div className="search-container">
           <SearchBar handleSearchInput={this.handleSearchInput} />
           <SearchOptions
+            handleToggle={this.handleOptionsToggle}
             open={displayOptions}
           />
           {

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ class App extends Component {
     this.searchDebounce = null;
 
     this.handleOptionsToggle = this.handleOptionsToggle.bind(this);
+    this.handleSortFilterChange = this.handleSortFilterChange.bind(this);
     this.handleSearchInput = this.handleSearchInput.bind(this);
   }
 
@@ -36,6 +37,12 @@ class App extends Component {
   handleSearchInput(term) {
     clearTimeout(this.searchDebounce);
     this.searchDebounce = setTimeout(() => this.search(term), 500);
+  }
+
+  handleSortFilterChange(event, index, value) {
+    this.setState({
+      sortFilter: value
+    });
   }
 
   async search(term) {
@@ -74,6 +81,7 @@ class App extends Component {
         <div className="search-container">
           <SearchBar handleSearchInput={this.handleSearchInput} />
           <SearchOptions
+            handleSortFilterChange={this.handleSortFilterChange}
             handleToggle={this.handleOptionsToggle}
             open={displayOptions}
             sortFilter={sortFilter}

--- a/src/App.js
+++ b/src/App.js
@@ -24,12 +24,10 @@ class App extends Component {
 
     this.searchDebounce = null;
 
-    this.handleSearchOptionsToggle = this.handleSearchOptionsToggle.bind(this);
-    this.handleSortFilterChange = this.handleSortFilterChange.bind(this);
     this.handleSearchInput = this.handleSearchInput.bind(this);
   }
 
-  handleSearchOptionsToggle() {
+  handleSearchOptionsToggle = () => {
     this.setState({
       displaySearchOptions: !this.state.displaySearchOptions
     });
@@ -40,7 +38,7 @@ class App extends Component {
     this.searchDebounce = setTimeout(() => this.search(term), 500);
   }
 
-  handleSortFilterChange(event, index, value) {
+  handleSortFilterChange = (event, index, value) => {
     this.setState({
       sortFilter: value
     }, () => this.search(this.state.searchTerm));

--- a/src/App.js
+++ b/src/App.js
@@ -24,12 +24,12 @@ class App extends Component {
 
     this.searchDebounce = null;
 
-    this.handleOptionsToggle = this.handleOptionsToggle.bind(this);
+    this.handleSearchOptionsToggle = this.handleSearchOptionsToggle.bind(this);
     this.handleSortFilterChange = this.handleSortFilterChange.bind(this);
     this.handleSearchInput = this.handleSearchInput.bind(this);
   }
 
-  handleOptionsToggle() {
+  handleSearchOptionsToggle() {
     this.setState({
       displaySearchOptions: !this.state.displaySearchOptions
     });
@@ -77,7 +77,7 @@ class App extends Component {
           />
           <SearchOptions
             handleSortFilterChange={this.handleSortFilterChange}
-            handleToggle={this.handleOptionsToggle}
+            handleToggle={this.handleSearchOptionsToggle}
             open={displaySearchOptions}
             sortFilter={sortFilter}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ class App extends Component {
 
     this.state = {
       currentPage: 1,
+      displayOptions: false,
       results: [],
       searchTerm: ''
     };
@@ -55,7 +56,7 @@ class App extends Component {
   }
 
   render() {
-    const { searchTerm, results } = this.state;
+    const { displayOptions, searchTerm, results } = this.state;
 
     return (
       <div>
@@ -65,7 +66,9 @@ class App extends Component {
         />
         <div className="search-container">
           <SearchBar handleSearchInput={this.handleSearchInput} />
-          <SearchOptions />
+          <SearchOptions
+            open={displayOptions}
+          />
           {
             searchTerm.length > 0
             ? <Results results={results} searchTerm={searchTerm} />

--- a/src/SearchBar/SearchBar.js
+++ b/src/SearchBar/SearchBar.js
@@ -2,11 +2,18 @@ import React from 'react';
 
 import TextField from 'material-ui/TextField';
 
-const SearchBar = ({ handleSearchInput }) => {
+const sortFilterDict = {
+  '': 'Best Match',
+  'forks': 'Forks',
+  'stars': 'Stars',
+  'updated': 'Recently Updated'
+};
+
+const SearchBar = ({ handleSearchInput, sortFilter }) => {
   return (
     <div>
       <TextField
-        floatingLabelText="Search"
+        floatingLabelText={`Search (sorted by ${sortFilterDict[sortFilter]})`}
         fullWidth
         onChange={(e) => handleSearchInput(e.target.value)}
       />

--- a/src/SearchBar/SearchBar.test.js
+++ b/src/SearchBar/SearchBar.test.js
@@ -41,6 +41,30 @@ describe('SearchBar', () => {
     expect(textField.length).toEqual(1);
   });
 
+  it('should render a label with \'Sorted by Best Match\' when the sort filter is empty', () => {
+    props.sortFilter = '';
+    const textField = searchBarMounted().find('TextField');
+    expect(textField.find('label').text()).toEqual('Search (sorted by Best Match)');
+  });
+
+  it('should render a label with \'Sorted by Forks\' when the sort filter is forks', () => {
+    props.sortFilter = 'forks';
+    const textField = searchBarMounted().find('TextField');
+    expect(textField.find('label').text()).toEqual('Search (sorted by Forks)');
+  });
+
+  it('should render a label with \'Sorted by Stars\' when the sort filter is stars', () => {
+    props.sortFilter = 'stars';
+    const textField = searchBarMounted().find('TextField');
+    expect(textField.find('label').text()).toEqual('Search (sorted by Stars)');
+  });
+
+  it('should render a label with \'Sorted by Recently Updated\' when the sort filter is updated', () => {
+    props.sortFilter = 'updated';
+    const textField = searchBarMounted().find('TextField');
+    expect(textField.find('label').text()).toEqual('Search (sorted by Recently Updated)');
+  });
+
   it('should call the handleSearchInput function when text is entered', () => {
     props.handleSearchInput = jest.fn();
 

--- a/src/SearchOptions/SearchOptions.css
+++ b/src/SearchOptions/SearchOptions.css
@@ -1,0 +1,29 @@
+.search-options {
+  box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
+}
+.search-options-panel {
+  max-height: 0;
+  overflow: auto;
+  padding: 0 10px;
+  transition: max-height 800ms ease-in-out 0ms;
+}
+.search-options-panel-open {
+  max-height: 1000px;
+}
+.search-options-panel-content {
+  padding: 10px 0;
+}
+.search-options-toggle-panel {
+  background-color: #E8E8E8;
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: flex;
+  height: 30px;
+  justify-content: space-between;
+  padding: 0 12px;
+}
+.search-options-toggle-panel-content {
+  align-items: center;
+  display: flex;
+  position: relative;
+}

--- a/src/SearchOptions/SearchOptions.css
+++ b/src/SearchOptions/SearchOptions.css
@@ -11,9 +11,6 @@
   max-height: 1000px;
   overflow: hidden;
 }
-.search-options-panel-content {
-
-}
 .search-options-toggle-panel {
   background-color: #E8E8E8;
   border: 1px solid transparent;

--- a/src/SearchOptions/SearchOptions.css
+++ b/src/SearchOptions/SearchOptions.css
@@ -9,6 +9,7 @@
 }
 .search-options-panel-open {
   max-height: 1000px;
+  overflow: hidden;
 }
 .search-options-panel-content {
 

--- a/src/SearchOptions/SearchOptions.css
+++ b/src/SearchOptions/SearchOptions.css
@@ -11,7 +11,7 @@
   max-height: 1000px;
 }
 .search-options-panel-content {
-  padding: 10px 0;
+
 }
 .search-options-toggle-panel {
   background-color: #E8E8E8;

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -33,7 +33,7 @@ const SearchOptions = ({
             : <ArrowRight />
           }
           </IconButton>
-          <span>Advanced Search</span>
+          <span>Filters</span>
         </div>
       </div>
       <div className={panelClasses}>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -1,5 +1,9 @@
 import React from 'react';
 
+import IconButton from 'material-ui/IconButton';
+import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
+import ArrowRight from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
+
 const styles = {
   'search-options': {
     boxShadow: 'rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px'
@@ -45,6 +49,12 @@ const SearchOptions = ({ open }) => {
         style={styles['search-options-toggle-panel']}
       >
         <div style={styles['search-options-toggle-panel-content']}>
+          <IconButton>
+          { open
+            ? <ArrowDown />
+            : <ArrowRight />
+          }
+          </IconButton>
           <span>Advanced Search</span>
         </div>
       </div>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -59,6 +59,6 @@ function buildSortOptions() {
     <MenuItem key={1} value='' primaryText='Best Match' />,
     <MenuItem key={2} value='forks' primaryText='Forks' />,
     <MenuItem key={3} value='stars' primaryText='Stars' />,
-    <MenuItem key={4} value='updated' primaryText='Last Updated' />
+    <MenuItem key={4} value='updated' primaryText='Recently Updated' />
   ];
 }

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -37,7 +37,7 @@ const styles = {
   }
 };
 
-const SearchOptions = ({ open }) => {
+const SearchOptions = ({ handleToggle, open }) => {
   const panelStyles =
     open
     ? {...styles['search-options-panel'], ...styles['search-options-panel-open']}
@@ -46,6 +46,7 @@ const SearchOptions = ({ open }) => {
   return (
     <div style={styles['search-options']}>
       <div
+        onClick={handleToggle}
         style={styles['search-options-toggle-panel']}
       >
         <div style={styles['search-options-toggle-panel-content']}>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -2,12 +2,19 @@ import React from 'react';
 
 import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
+import SelectField  from 'material-ui/SelectField';
+
 import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
 import ArrowRight from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
 
 import './SearchOptions.css';
 
-const SearchOptions = ({ handleToggle, open }) => {
+const SearchOptions = ({
+  handleSortFilterChange,
+  handleToggle,
+  open,
+  sortFilter
+}) => {
   const panelClasses =
     open
     ? 'search-options-panel search-options-panel-open'
@@ -31,7 +38,14 @@ const SearchOptions = ({ handleToggle, open }) => {
       </div>
       <div className={panelClasses}>
         <div className='search-options-panel-content'>
-          <div>Search Contents</div>
+          <SelectField
+            floatingLabelText='Sort By'
+            floatingLabelFixed
+            onChange={handleSortFilterChange}
+            value={sortFilter}
+          >
+            {buildSortOptions()}
+          </SelectField>
         </div>
       </div>
     </div>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const SearchOptions = (props) => {
+  return (
+    <div>Search Options</div>
+  );
+};
+
+export default SearchOptions;

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -4,52 +4,21 @@ import IconButton from 'material-ui/IconButton';
 import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
 import ArrowRight from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
 
-const styles = {
-  'search-options': {
-    boxShadow: 'rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px'
-  },
-  'search-options-panel': {
-    maxHeight: '0',
-    overflow: 'auto',
-    padding: '0 10px',
-    transition: 'max-height 800ms ease-in-out 0ms'
-  },
-  'search-options-panel-open': {
-    maxHeight: '1000px'
-  },
-  'search-options-panel-content': {
-    padding: '10px 0'
-  },
-  'search-options-toggle-panel': {
-    backgroundColor: '#E8E8E8',
-    border: '1px solid transparent',
-    cursor: 'pointer',
-    display: 'flex',
-    height: '30px',
-    justifyContent: 'space-between',
-    padding: '0 12px'
-  },
-  'search-options-toggle-panel-content': {
-    alignItems: 'center',
-    display: 'flex',
-    position: 'relative',
-
-  }
-};
+import './SearchOptions.css';
 
 const SearchOptions = ({ handleToggle, open }) => {
-  const panelStyles =
+  const panelClasses =
     open
-    ? {...styles['search-options-panel'], ...styles['search-options-panel-open']}
-    : styles['search-options-panel'];
+    ? 'search-options-panel search-options-panel-open'
+    : 'search-options-panel';
 
   return (
-    <div style={styles['search-options']}>
+    <div className='search-options'>
       <div
         onClick={handleToggle}
-        style={styles['search-options-toggle-panel']}
+        className='search-options-toggle-panel'
       >
-        <div style={styles['search-options-toggle-panel-content']}>
+        <div className='search-options-toggle-panel-content'>
           <IconButton>
           { open
             ? <ArrowDown />
@@ -59,8 +28,8 @@ const SearchOptions = ({ handleToggle, open }) => {
           <span>Advanced Search</span>
         </div>
       </div>
-      <div style={panelStyles}>
-        <div style={styles['search-options-panel-content']}>
+      <div className={panelClasses}>
+        <div className='search-options-panel-content'>
           <div>Search Contents</div>
         </div>
       </div>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -10,6 +10,9 @@ const styles = {
     padding: '0 10px',
     transition: 'max-height 800ms ease-in-out 0ms'
   },
+  'search-options-panel-open': {
+    maxHeight: '1000px'
+  },
   'search-options-panel-content': {
     padding: '10px 0'
   },
@@ -30,7 +33,12 @@ const styles = {
   }
 };
 
-const SearchOptions = (props) => {
+const SearchOptions = ({ open }) => {
+  const panelStyles =
+    open
+    ? {...styles['search-options-panel'], ...styles['search-options-panel-open']}
+    : styles['search-options-panel'];
+
   return (
     <div style={styles['search-options']}>
       <div
@@ -40,7 +48,7 @@ const SearchOptions = (props) => {
           <span>Advanced Search</span>
         </div>
       </div>
-      <div style={styles['search-options-panel']}>
+      <div style={panelStyles}>
         <div style={styles['search-options-panel-content']}>
           <div>Search Contents</div>
         </div>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import IconButton from 'material-ui/IconButton';
+import MenuItem from 'material-ui/MenuItem';
 import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
 import ArrowRight from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
 
@@ -38,3 +39,12 @@ const SearchOptions = ({ handleToggle, open }) => {
 }
 
 export default SearchOptions;
+
+function buildSortOptions() {
+  return [
+    <MenuItem key={1} value='' primaryText='Best Match' />,
+    <MenuItem key={2} value='forks' primaryText='Forks' />,
+    <MenuItem key={3} value='stars' primaryText='Stars' />,
+    <MenuItem key={4} value='updated' primaryText='Last Updated' />
+  ];
+}

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -4,8 +4,8 @@ import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
 import SelectField  from 'material-ui/SelectField';
 
-import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
-import ArrowRight from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
+import HardwareKeyboardArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
+import HardwareKeyboardArrowRight from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
 
 import './SearchOptions.css';
 
@@ -29,8 +29,8 @@ const SearchOptions = ({
         <div className='search-options-toggle-panel-content'>
           <IconButton>
           { open
-            ? <ArrowDown />
-            : <ArrowRight />
+            ? <HardwareKeyboardArrowDown />
+            : <HardwareKeyboardArrowRight />
           }
           </IconButton>
           <span>Filters</span>

--- a/src/SearchOptions/SearchOptions.js
+++ b/src/SearchOptions/SearchOptions.js
@@ -1,9 +1,52 @@
 import React from 'react';
 
+const styles = {
+  'search-options': {
+    boxShadow: 'rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px'
+  },
+  'search-options-panel': {
+    maxHeight: '0',
+    overflow: 'auto',
+    padding: '0 10px',
+    transition: 'max-height 800ms ease-in-out 0ms'
+  },
+  'search-options-panel-content': {
+    padding: '10px 0'
+  },
+  'search-options-toggle-panel': {
+    backgroundColor: '#E8E8E8',
+    border: '1px solid transparent',
+    cursor: 'pointer',
+    display: 'flex',
+    height: '30px',
+    justifyContent: 'space-between',
+    padding: '0 12px'
+  },
+  'search-options-toggle-panel-content': {
+    alignItems: 'center',
+    display: 'flex',
+    position: 'relative',
+
+  }
+};
+
 const SearchOptions = (props) => {
   return (
-    <div>Search Options</div>
+    <div style={styles['search-options']}>
+      <div
+        style={styles['search-options-toggle-panel']}
+      >
+        <div style={styles['search-options-toggle-panel-content']}>
+          <span>Advanced Search</span>
+        </div>
+      </div>
+      <div style={styles['search-options-panel']}>
+        <div style={styles['search-options-panel-content']}>
+          <div>Search Contents</div>
+        </div>
+      </div>
+    </div>
   );
-};
+}
 
 export default SearchOptions;

--- a/src/SearchOptions/SearchOptions.test.js
+++ b/src/SearchOptions/SearchOptions.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import SearchOptions from './SearchOptions';
+
+describe('SearchOptions', () => {
+  let props;
+  let shallowSearchOptions;
+  let mountedSearchOptions;
+
+  const searchOptionsShallow = () => {
+    if(!shallowSearchOptions) {
+      shallowSearchOptions = shallow(
+        <SearchOptions {...props} />
+      );
+    }
+    return shallowSearchOptions;
+  };
+
+  const searchOptionsMounted = () => {
+    if(!mountedSearchOptions) {
+      mountedSearchOptions = mount(
+        <SearchOptions {...props} />
+      );
+    }
+    return mountedSearchOptions;
+  };
+
+  beforeEach(() => {
+    props = {
+      
+    };
+
+    shallowSearchOptions = undefined;
+    mountedSearchOptions = undefined;
+  });
+});

--- a/src/SearchOptions/SearchOptions.test.js
+++ b/src/SearchOptions/SearchOptions.test.js
@@ -53,6 +53,17 @@ describe('SearchOptions', () => {
     expect(menuItems.get(3).props.value).toEqual('updated');
   });
 
+  it('displays the HardwareKeyboardArrowRight SVG icon when the search options panel is closed', () => {
+    const panelContent = searchOptionsShallow().find('.search-options-toggle-panel-content IconButton HardwareKeyboardArrowRight');
+    expect(panelContent.length).toEqual(1);
+  });
+
+  it('displays the HardwareKeyboardArrowDown SVG icon when the search options panel is open', () => {
+    props.open = true;
+    const panelContent = searchOptionsShallow().find('.search-options-toggle-panel-content IconButton HardwareKeyboardArrowDown');
+    expect(panelContent.length).toEqual(1);
+  });
+
   it('calls handleSortFilterChange function when the sort filter SelectField is changed', () => {
     props.handleSortFilterChange = jest.fn();
     const select = searchOptionsShallow().find('SelectField');

--- a/src/SearchOptions/SearchOptions.test.js
+++ b/src/SearchOptions/SearchOptions.test.js
@@ -27,7 +27,10 @@ describe('SearchOptions', () => {
 
   beforeEach(() => {
     props = {
-      
+      handleSortFilterChange: () => false,
+      handleToggle: () => false,
+      open: false,
+      sortFilter: ''
     };
 
     shallowSearchOptions = undefined;

--- a/src/SearchOptions/SearchOptions.test.js
+++ b/src/SearchOptions/SearchOptions.test.js
@@ -36,4 +36,38 @@ describe('SearchOptions', () => {
     shallowSearchOptions = undefined;
     mountedSearchOptions = undefined;
   });
+
+  it('renders a div with search-options class', () => {
+    expect(searchOptionsShallow().find('.search-options').length).toEqual(1);
+  });
+
+  it('renders a SelectField with 4 MenuItem children', () => {
+    const select = searchOptionsShallow().find('SelectField');
+    expect(select.length).toEqual(1);
+    const menuItems = select.find('MenuItem');
+    expect(menuItems.length).toEqual(4);
+
+    expect(menuItems.get(0).props.value).toEqual('');
+    expect(menuItems.get(1).props.value).toEqual('forks');
+    expect(menuItems.get(2).props.value).toEqual('stars');
+    expect(menuItems.get(3).props.value).toEqual('updated');
+  });
+
+  it('calls handleSortFilterChange function when the sort filter SelectField is changed', () => {
+    props.handleSortFilterChange = jest.fn();
+    const select = searchOptionsShallow().find('SelectField');
+    select.simulate('change');
+    expect(props.handleSortFilterChange.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the handleToggle function when the toggle panel is clicked', () => {
+    props.handleToggle = jest.fn();
+    const togglePanel = searchOptionsShallow().find('.search-options-toggle-panel').simulate('click');
+    expect(props.handleToggle.mock.calls.length).toEqual(1);
+  });
+
+  it('sets the value of the SelectField when the sortFilter prop is set', () => {
+    props.sortFilter = 'forks';
+    expect(searchOptionsShallow().find('SelectField').prop('value')).toEqual('forks');
+  });
 });


### PR DESCRIPTION
I added a collapsible panel underneath the search bar that contains search filters. For now, since we are only able to search repositories and the only filter available through the API is sort, the only filter is Sort By. This supports 4 values: Best Match (default), Forks, Stars, and Last Updated.

The sort filter itself is stored in the state of the App component along with the other functions passed into the SearchOptions component's props.

Now, in the SearchBar label, it identifies the current filter and adds some text indicating the active filter.